### PR TITLE
Improve admin check with immediate verification

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const client = require('./client');
+const config = require('./dono/config.json');
+
+const app = express();
+app.use(express.json());
+app.use('/sorteios', require('./routes/sorteios'));
+
+// Verifica se um usuário é administrador diretamente no grupo
+async function isAdmin(chatId, userId) {
+  const chat = await client.getChatById(chatId);
+  if (!chat.isGroup) return false;
+  const participant = chat.participants.find(p => p.id._serialized === userId);
+  return participant ? participant.isAdmin : false;
+}
+
+client.on('message', async msg => {
+  if (!msg.from.endsWith('@g.us')) return; // apenas grupos
+  const userId = msg.author || msg.from;
+  const admin = await isAdmin(msg.from, userId);
+  console.log(`Mensagem de ${userId} em ${msg.from} - Admin: ${admin}`);
+});
+
+const PORT = Number(config.portaexpres) || 7000;
+app.listen(PORT, () => console.log(`Servidor express iniciado na porta ${PORT}`));


### PR DESCRIPTION
## Summary
- add index.js Express server to integrate client
- verify admin status directly via group metadata

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861814518288323bc8bef78fd265c8d